### PR TITLE
Update to current Rust

### DIFF
--- a/src/fnbox.rs
+++ b/src/fnbox.rs
@@ -1,0 +1,27 @@
+//! Boxed FnOnce trait objects
+
+/// Trait to wrap to build `FnOnce() -> A` trait objects
+///
+/// This works by only allowing to call the trait objects, when they are boxed.
+/// In this way they become object-safe.
+///
+/// It has been adapted from an unstable part of the standard library and
+/// specialized to 0-arity functions for the use case relevant for this crate.
+/// (NOTE: an implementation generic over arity would require an additional
+/// unstable feature `unboxed_closures`.)
+pub trait FnBox {
+    /// Return type of the boxed function
+    type Output;
+
+    /// Call the boxed function
+    fn call_box(self: Box<Self>, args: ()) -> Self::Output;
+}
+
+impl<A, F: FnOnce() -> A> FnBox for F
+{
+    type Output = A;
+
+    fn call_box(self: Box<F>, _: ()) -> F::Output {
+        (*self)()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, warnings)]
-#![feature(core, std_misc, unsafe_destructor, optin_builtin_traits)]
+#![feature(core, unsafe_destructor, optin_builtin_traits)]
 
 //! Lazy evaluation for Rust.
 
@@ -13,6 +13,8 @@ pub mod single;
 
 /// A Thunk safe for multi-threaded use.
 pub mod sync;
+
+mod fnbox;
 
 mod lazy {
     pub use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, warnings)]
-#![feature(core, unsafe_destructor, optin_builtin_traits)]
+#![feature(core)]
 
 //! Lazy evaluation for Rust.
 

--- a/src/single.rs
+++ b/src/single.rs
@@ -1,9 +1,9 @@
 use std::ops::{Deref, DerefMut};
 use std::cell::UnsafeCell;
 use std::ptr;
-use std::thunk::Invoke;
 
 use self::Inner::{Evaluated, EvaluationInProgress, Unevaluated};
+use fnbox::FnBox;
 
 /// A sometimes-cleaner name for a lazily evaluated value.
 pub type Lazy<'a, T> = Thunk<'a, T>;
@@ -23,9 +23,9 @@ impl<'a, T> Thunk<'a, T> {
     ///
     /// ```rust
     /// # use lazy::single::Thunk;
-    /// let expensive = Thunk::new(|| { println!("Evaluated!"); 7u });
-    /// assert_eq!(*expensive, 7u); // "Evaluated!" gets printed here.
-    /// assert_eq!(*expensive, 7u); // Nothing printed.
+    /// let expensive = Thunk::new(|| { println!("Evaluated!"); 7 });
+    /// assert_eq!(*expensive, 7); // "Evaluated!" gets printed here.
+    /// assert_eq!(*expensive, 7); // Nothing printed.
     /// ```
     pub fn new<F>(producer: F) -> Thunk<'a, T>
     where F: 'a + FnOnce() -> T {
@@ -71,20 +71,16 @@ impl<'a, T> Thunk<'a, T> {
 }
 
 struct Producer<'a, T> {
-    inner: Box<Invoke<(), T> + 'a>
+    inner: Box<FnBox<Output=T> + 'a>
 }
 
 impl<'a,T> Producer<'a,T> {
     fn new<F: 'a + FnOnce() -> T>(f: F) -> Producer<'a,T> {
-        Producer {
-            inner: Box::new(move |()| {
-                f()
-            }) as Box<Invoke<(), T>>
-        }
+        Producer { inner: Box::new(f) }
     }
 
     fn invoke(self) -> T {
-        self.inner.invoke(())
+        self.inner.call_box(())
     }
 }
 

--- a/src/single.rs
+++ b/src/single.rs
@@ -13,8 +13,6 @@ pub struct Thunk<'a, T> {
     inner: UnsafeCell<Inner<'a, T>>,
 }
 
-impl<'a, T> !Sync for Thunk<'a, T> {}
-
 impl<'a, T> Thunk<'a, T> {
     /// Create a lazily evaluated value from a proc that returns that value.
     ///
@@ -63,7 +61,7 @@ impl<'a, T> Thunk<'a, T> {
         self.force();
         unsafe {
             match self.inner.into_inner() {
-                Evaluated(val) => { val },
+                Evaluated(val) => val,
                 _ => debug_unreachable!()
             }
         }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, std_misc, old_io)]
+#![feature(plugin)]
 #![plugin(stainless)]
 
 #[macro_use]
@@ -6,7 +6,6 @@ extern crate lazy;
 
 pub use lazy::sync::Thunk;
 pub use std::sync::{Arc, Barrier, Mutex};
-pub use std::{old_io, time};
 pub use std::thread;
 
 describe! sync {
@@ -42,11 +41,7 @@ describe! sync {
     }
 
     it "should be safe to access while evaluating" {
-        let data = Arc::new(sync_lazy!({
-            old_io::timer::sleep(time::Duration::milliseconds(50));
-            5
-        }));
-
+        let data = Arc::new(sync_lazy!({ thread::sleep_ms(50); 5 }));
         let data_worker = data.clone();
 
         // Worker task.


### PR DESCRIPTION
See commit messages for details. The first part simply makes the crate compile again, while the second part gets rid of using some unstable features.

Pending on getting stainless and oncemutex to build again.
